### PR TITLE
fix: Remove /api prefix from FastAPI routers for correct Vercel routing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -127,10 +127,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Include routers
-app.include_router(compile.router, prefix="/api", tags=["Resume"])
-app.include_router(cover_letter.router, prefix="/api", tags=["Cover Letter"])
-app.include_router(upload.router, prefix="/api", tags=["Upload"])
+# Include routers (no /api prefix - the rewrite adds /api/py)
+app.include_router(compile.router, tags=["Resume"])
+app.include_router(cover_letter.router, tags=["Cover Letter"])
+app.include_router(upload.router, tags=["Upload"])
 
 
 @app.get("/")


### PR DESCRIPTION
BREAKING CHANGE: FastAPI routes changed from /api/* to just /*

- Incoming path: /api/py/upload/resume (from rewrite)
- FastAPI now matches: /upload/resume (no /api prefix)
- This fixes the 405 Method Not Allowed error

Tested locally:
- Direct backend: curl POST localhost:8000/upload/resume ✓
- Through Next.js: curl POST localhost:3000/api/profile/upload ✓

For production: /api/py/upload/resume will now correctly route to FastAPI