### PR TITLE
fix: Add ASGI path-fixing middleware for Vercel rewrites

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,15 +1,70 @@
-# /api/main.py
-# Vercel Serverless Function entrypoint for FastAPI
-# This file exposes the FastAPI app as a single Vercel Python function
+"""
+Vercel Serverless Function entrypoint for FastAPI
+Handles Next.js rewrites by extracting path from query parameters
+"""
 
 import sys
 import os
+from urllib.parse import parse_qs
 
-# Add backend directory to Python path so we can import from it
+# Add backend directory to Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
 
-# Import the FastAPI app instance from backend
+# Import the FastAPI app instance
 from app.main import app
 
-# Vercel requires the app to be available at module level
-# The 'app' variable is automatically detected by Vercel
+
+class VercelPathFixerMiddleware:
+    """
+    ASGI middleware to fix path routing for Vercel rewrites.
+    
+    Vercel/Next.js rewrites send path as query param:
+      x-nextjs-rewritten-query: path=upload/resume
+    
+    This middleware extracts it and overwrites scope['path'] so 
+    FastAPI can route correctly.
+    """
+    
+    def __init__(self, app):
+        self.app = app
+    
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            # Extract query string
+            query_string = scope.get("query_string", b"").decode("utf-8")
+            
+            if query_string:
+                # Parse query parameters
+                query_params = parse_qs(query_string)
+                
+                # Check if 'path' parameter exists (from Next.js rewrite)
+                if "path" in query_params:
+                    # Get the path value
+                    path_value = query_params["path"][0]
+                    
+                    # Ensure it starts with /
+                    if not path_value.startswith("/"):
+                        path_value = f"/{path_value}"
+                    
+                    # Override the ASGI path
+                    scope["path"] = path_value
+                    
+                    # Clean up query string (remove path param)
+                    remaining_params = {
+                        k: v for k, v in query_params.items() if k != "path"
+                    }
+                    if remaining_params:
+                        # Rebuild query string without path param
+                        new_qs = "&".join(
+                            f"{k}={v[0]}" for k, v in remaining_params.items()
+                        )
+                        scope["query_string"] = new_qs.encode("utf-8")
+                    else:
+                        scope["query_string"] = b""
+        
+        # Call the FastAPI app with the modified scope
+        await self.app(scope, receive, send)
+
+
+# Wrap the FastAPI app with the path fixer middleware
+app = VercelPathFixerMiddleware(app)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -93,11 +93,13 @@ async def lifespan(app: FastAPI):
     logger.info("[SHUTDOWN] CV-Wiz API shutdown complete")
 
 
+
 app = FastAPI(
     title="CV-Wiz API",
     description="Career Resume Compiler - Generate tailored resumes and cover letters",
     version="1.0.0",
     lifespan=lifespan,
+    root_path="/api/py",  # For Vercel deployment with Next.js rewrites
 )
 
 # Add logging middleware FIRST


### PR DESCRIPTION
CRITICAL FIX for HTTP 405 error on Vercel:

Problem:
- Next.js rewrite sends path as query param: path=upload/resume
- ASGI scope['path'] was /api/index.py, not /upload/resume
- FastAPI couldn't match routes → 405 Method Not Allowed

Solution:
1. Created VercelPathFixerMiddleware in api/index.py
   - Extracts 'path' from query_string
   - Overwrites scope['path'] with correct value
   - Ensures FastAPI receives /upload/resume

2. Added root_path='/api/py' to FastAPI app
   - Helps with OpenAPI docs
   - Clarifies app is mounted at /api/py

Testing:
Expected change in curl output:
- Before: x-matched-path: /404
- After:  x-matched-path: /api/py/upload/resume (or similar)
- Status: 200 instead of 405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved API path routing and request handling for Next.js and Vercel deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->